### PR TITLE
Fix heading typo in run_hypoTest

### DIFF
--- a/test/run_hypoTest.py
+++ b/test/run_hypoTest.py
@@ -24,7 +24,7 @@ print("@@@ Setting up...")
 print("@@@ MAXRSS now = ", resource.getrusage(resource.RUSAGE_SELF).ru_maxrss/1024)
 
 ###############################################################################
-## Set contants
+## Set constants
 ###############################################################################
 nSignal = args.n_signal
 dm41 = args.dm41


### PR DESCRIPTION
## Summary
- fix a typo in `run_hypoTest.py` heading comment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b7dd1b9c4832bb5de0c91005e3f5b