### PR TITLE
Fix getFileAndObj path parsing

### DIFF
--- a/python/Config.py
+++ b/python/Config.py
@@ -84,9 +84,10 @@ class ConfigRENE(Config):
     return baselines
 
 def getFileAndObj(path):
+  """Return ROOT file and object; ``hPath`` is ``None`` if no colon is supplied."""
   path = path.split(':', 1)
   fPath = path[0]
-  hPath = path[1] if len(path) > 0 else None
+  hPath = path[1] if len(path) > 1 else None
 
   f = ROOT.TFile(fPath)
   h = f.Get(hPath)


### PR DESCRIPTION
## Summary
- fix the conditional when no colon is provided to `getFileAndObj`
- note that `hPath` may be `None`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b7dc61468832bb0b2eb4de98f6ad1